### PR TITLE
[FIX] 그룹 상세 페이지 API 변경 사항 적용 및 에러 처리

### DIFF
--- a/src/app/group/[groupId]/not-found.tsx
+++ b/src/app/group/[groupId]/not-found.tsx
@@ -1,0 +1,3 @@
+export default function GroupDetailNotFoundPAge() {
+  return <div>존재하지 않는 모임입니다.</div>;
+}

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -2,7 +2,7 @@ import { request } from '@/api/request';
 import { GroupDescription } from '@/components/atoms/group-description';
 import { GroupActionButtons } from '@/components/molecules/gorup-action-buttons';
 import { GroupDetaiilCard } from '@/components/organisms/group-detail-card';
-import { ReplyList } from '@/components/organisms/reply/reply-list';
+import { ReplySection } from '@/components/organisms/reply/reply-section';
 import { GroupDetail } from '@/types';
 import { CommonResponse } from '@/types/response';
 import { notFound } from 'next/navigation';
@@ -41,7 +41,7 @@ export default async function GroupDetailPage({
       <main className="w-4/5 mx-auto flex flex-col gap-10">
         <GroupDetaiilCard info={data} />
         <GroupDescription description={groupInfo.description} />
-        <ReplyList />
+        <ReplySection />
       </main>
       <footer className="fixed bottom-0 z-50 bg-white border-t-2 py-2 px-5 w-full flex justify-end gap-3">
         <GroupActionButtons hostId={host.userId} isApplicant={isApplicant} />

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -29,7 +29,8 @@ export default async function GroupDetailPage({
     }
 
     data = response.data;
-  } catch {
+  } catch (err) {
+    console.error(err);
     notFound();
   }
 
@@ -43,10 +44,7 @@ export default async function GroupDetailPage({
         <ReplyList />
       </main>
       <footer className="fixed bottom-0 z-50 bg-white border-t-2 py-2 px-5 w-full flex justify-end gap-3">
-        <GroupActionButtons
-          hostId={host.userId.toString()}
-          isApplicant={isApplicant}
-        />
+        <GroupActionButtons hostId={host.userId} isApplicant={isApplicant} />
       </footer>
     </div>
   );

--- a/src/components/atoms/apply-join-button.tsx/index.tsx
+++ b/src/components/atoms/apply-join-button.tsx/index.tsx
@@ -29,6 +29,7 @@ export const ApplyJoinButton = ({
         `/v2/groups/${groupId}/applications`,
         {},
         JSON.stringify({}),
+        { credentials: 'include' },
       ),
     onError: () => {
       toast.error('참여 신청에 실패하였습니다. 잠시 후 다시 시도해주세요.');

--- a/src/components/atoms/bookmark-button/index.tsx
+++ b/src/components/atoms/bookmark-button/index.tsx
@@ -21,7 +21,12 @@ export const BookmarkButton = ({
 
   const { mutate } = useMutation({
     mutationFn: (isBookmark: boolean) =>
-      request.patch('/v2/bookmark', {}, { groupId, isBookmark }),
+      request.patch(
+        '/v2/bookmark',
+        { 'Content-Type': 'application/json' },
+        { groupId, isBookmark },
+        { credentials: 'include' },
+      ),
     onError: () => {
       toast.error('찜하기에 실패하였습니다.');
       setIsBookmark((prev) => !prev);

--- a/src/components/atoms/bookmark-button/index.tsx
+++ b/src/components/atoms/bookmark-button/index.tsx
@@ -24,7 +24,7 @@ export const BookmarkButton = ({
       request.patch(
         '/v2/bookmark',
         { 'Content-Type': 'application/json' },
-        { groupId, isBookmark },
+        { groupId, bookmark: isBookmark },
         { credentials: 'include' },
       ),
     onError: () => {

--- a/src/components/atoms/cancel-group-button/index.tsx
+++ b/src/components/atoms/cancel-group-button/index.tsx
@@ -11,7 +11,8 @@ export const CancelGroupButton = () => {
   const { groupId } = useParams<{ groupId: string }>();
 
   const { mutate, isPending } = useMutation({
-    mutationFn: () => request.delete(`/v2/groups/${groupId}`),
+    mutationFn: () =>
+      request.delete(`/v2/groups/${groupId}`, { credentials: 'include' }),
     onError: () => {
       toast.error('모임 취소에 실패하였습니다. 잠시 후 다시 시도해주세요.');
     },

--- a/src/components/atoms/cancel-join-button/index.tsx
+++ b/src/components/atoms/cancel-join-button/index.tsx
@@ -7,7 +7,10 @@ import { toast } from 'sonner';
 export const CancelJoinButton = ({ onSuccess }: { onSuccess: () => void }) => {
   const { groupId } = useParams<{ groupId: string }>();
   const { mutate, isPending } = useMutation({
-    mutationFn: () => request.delete(`/v2/groups/${groupId}/applications`),
+    mutationFn: () =>
+      request.delete(`/v2/groups/${groupId}/applications`, {
+        credentials: 'include',
+      }),
     onError: () => {
       toast.error(
         '참여 신청 취소에 실패하였습니다. 잠시 후 다시 시도해주세요.',

--- a/src/components/molecules/gorup-action-buttons/index.tsx
+++ b/src/components/molecules/gorup-action-buttons/index.tsx
@@ -8,7 +8,7 @@ import useAuthStore from '@/stores/useAuthStore';
 import { useState } from 'react';
 
 type GroupActionButtonsProps = {
-  hostId: string;
+  hostId: number;
   isApplicant: boolean;
 };
 

--- a/src/components/molecules/reply/reply-content.tsx
+++ b/src/components/molecules/reply/reply-content.tsx
@@ -34,6 +34,7 @@ export const ReplyContent = ({
         {
           content: enteredContent,
         },
+        { credentials: 'include' },
       ),
     onSuccess: () => {
       setIsEditing(false);
@@ -45,7 +46,9 @@ export const ReplyContent = ({
 
   const { mutate: deleteReply } = useMutation({
     mutationFn: async () =>
-      request.delete(`/v2/groups/${groupId}/replies/${replyId}`),
+      request.delete(`/v2/groups/${groupId}/replies/${replyId}`, {
+        credentials: 'include',
+      }),
     onSuccess: () => {
       // 서버에서 삭제 요청이 성공하면 UI에서도 반영
       onDelete?.();

--- a/src/components/molecules/reply/reply-form.tsx
+++ b/src/components/molecules/reply/reply-form.tsx
@@ -28,6 +28,7 @@ export const ReplyForm = ({ onSuccess, parentReplyId }: ReplyFormProps) => {
         endpoint,
         { 'Content-Type': 'application/json' },
         JSON.stringify({ content }),
+        { credentials: 'include' },
       ),
     onSuccess: (data) => {
       // 목록 무효화 후, 작성한 댓글로 이동

--- a/src/components/organisms/group-detail-card/index.tsx
+++ b/src/components/organisms/group-detail-card/index.tsx
@@ -3,9 +3,8 @@ import { Badge } from '@/components/atoms/badge';
 import { BookmarkButton } from '@/components/atoms/bookmark-button';
 import { Title } from '@/components/atoms/title';
 import { Progress } from '@/components/ui/progress';
-import { Group, UserSummary } from '@/types';
-import { getPosition, Skill } from '@/types/enums';
-import { formatYearMonthDayWithDot, isBeforeToday } from '@/utils/dateUtils';
+import { GroupDetail } from '@/types';
+import { isBeforeToday } from '@/utils/dateUtils';
 import { getDisplayNickname, getDisplayProfileImage } from '@/utils/fallback';
 import { getSkillBadge } from '@/utils/getSkillBadge';
 import Link from 'next/link';
@@ -13,17 +12,14 @@ import { ParticipantListModal } from '../participant-list-modal';
 
 type GroupDetaiilCardProps = {
   className?: string;
-  info: Group & {
-    host: UserSummary;
-    isApplicant: boolean;
-  };
+  info: GroupDetail;
 };
 
 export const GroupDetaiilCard = ({
   className,
   info,
 }: GroupDetaiilCardProps) => {
-  const deadline = new Date(info.deadline);
+  const deadline = new Date(info.groupInfo.deadline);
   const isBeforeDeadline = isBeforeToday(deadline);
 
   return (
@@ -35,54 +31,60 @@ export const GroupDetaiilCard = ({
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
               <Badge
-                text={info.type}
+                text={info.groupInfo.type}
                 className="border border-black rounded-sm px-1"
               />
-              <Title title={info.title} />
+              <Title title={info.groupInfo.title} />
             </div>
             <div className="flex gap-2">
-              {info.position.map((position) => (
+              {info.groupInfo.positions.map((position) => (
                 <Badge
                   key={position}
-                  text={getPosition(position)}
+                  text={position}
                   className="bg-gray-900 text-gray-100"
                 />
               ))}
             </div>
           </div>
-          <BookmarkButton groupId={info.id} isBookmark={info.isBookmark} />
+          <BookmarkButton
+            groupId={info.groupInfo.groupId}
+            isBookmark={info.bookmark}
+          />
         </header>
 
         {/* 모임 주최자 */}
         <section>
           <div className="flex gap-2 items-center">
             작성자:
-            <Link href={`/users/${info.host.userId}`} className="flex gap-2">
+            <Link
+              href={`/users/${info.userInfo.userId}`}
+              className="flex gap-2"
+            >
               <Avatar
-                imageSrc={getDisplayProfileImage(info.host.profileImage)}
+                imageSrc={getDisplayProfileImage(info.userInfo.profileImage)}
                 fallback={getDisplayNickname(
-                  info.host.nickname,
-                  info.host.email,
+                  info.userInfo.nickname,
+                  info.userInfo.email,
                 )}
               />
-              {getDisplayNickname(info.host.userId, info.host.email)}
+              {getDisplayNickname(info.userInfo.nickname, info.userInfo.email)}
             </Link>
           </div>
         </section>
 
         {/* 일정 정보 */}
         <section className="text-sm text-gray-600">
-          <div>모집 종료: {formatYearMonthDayWithDot(info.deadline)}</div>
-          <div>모임 시작: {formatYearMonthDayWithDot(info.startDate)}</div>
-          <div>모임 종료: {formatYearMonthDayWithDot(info.endDate)}</div>
+          <div>모집 종료: {info.groupInfo.deadline}</div>
+          <div>모임 시작: {info.groupInfo.startDate}</div>
+          <div>모임 종료: {info.groupInfo.endDate}</div>
         </section>
 
         {/* 기술 스택 */}
         <section>
           <span>사용 기술:</span>
           <ul className="flex gap-2 mt-1">
-            {info.skills.map((skill) => (
-              <li key={skill}>{getSkillBadge(Skill[skill])}</li>
+            {info.groupInfo.skills.map((skill) => (
+              <li key={skill}>{getSkillBadge(skill)}</li>
             ))}
           </ul>
         </section>
@@ -91,14 +93,16 @@ export const GroupDetaiilCard = ({
         <section>
           <div>
             <span>
-              참가 현황: {info.participants.length}/{info.maxParticipants}
+              참가 현황: {info.groupInfo.currentParticipants}/
+              {info.groupInfo.maxParticipants}
             </span>
           </div>
           <div className="flex items-center gap-2 ">
             <Progress value={50} />
             <div className="whitespace-nowrap">
               {isBeforeDeadline &&
-              info.participants.length < info.maxParticipants
+              info.groupInfo.currentParticipants <
+                info.groupInfo.maxParticipants
                 ? '모집중'
                 : '완료'}
             </div>
@@ -110,7 +114,7 @@ export const GroupDetaiilCard = ({
           <div className="flex gap-2">
             참가자 목록:
             <div className="flex">
-              {info.participants
+              {info.groupInfo.userInfos
                 .slice(0, 3)
                 .map(({ userId, profileImage, email, nickname }) => (
                   <Avatar
@@ -119,7 +123,7 @@ export const GroupDetaiilCard = ({
                     fallback={getDisplayNickname(nickname, email)}
                   />
                 ))}
-              <ParticipantListModal participants={info.participants} />
+              <ParticipantListModal participants={info.groupInfo.userInfos} />
             </div>
           </div>
         </section>

--- a/src/components/organisms/reply/reply-list.tsx
+++ b/src/components/organisms/reply/reply-list.tsx
@@ -7,6 +7,7 @@ import { useFetchItems } from '@/hooks/useFetchItems';
 import { useReplyScrollIntoView } from '@/hooks/useReplyScrollIntoView';
 import { useReplyScrollParams } from '@/hooks/useReplyScrollParams';
 import { Reply } from '@/types';
+import flattenPages from '@/utils/flattenPages';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
@@ -42,7 +43,7 @@ export const ReplyList = () => {
     setTargetReplyId(id);
   };
 
-  const replies = data.pages.flatMap((page) => page.items);
+  const replies = flattenPages(data.pages);
 
   return (
     <section>

--- a/src/components/organisms/reply/reply-section.tsx
+++ b/src/components/organisms/reply/reply-section.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ErrorBoundary } from '@/components/error-boundary';
+import { handleError } from '@/components/error-boundary/error-handler';
+import { ReplyList } from './reply-list';
+
+export const ReplySection = () => {
+  return (
+    <ErrorBoundary
+      fallback={({ error, resetErrorBoundary }) =>
+        handleError({
+          error,
+          resetErrorBoundary,
+          defaultMessage: '댓글을 불러오는 중 문제가 발생했습니다',
+        })
+      }
+    >
+      <ReplyList />
+    </ErrorBoundary>
+  );
+};

--- a/src/components/organisms/reply/rereply-list.tsx
+++ b/src/components/organisms/reply/rereply-list.tsx
@@ -4,6 +4,7 @@ import { useFetchInView } from '@/hooks/useFetchInView';
 import { useFetchItems } from '@/hooks/useFetchItems';
 import { useReplyScrollIntoView } from '@/hooks/useReplyScrollIntoView';
 import { Reply } from '@/types';
+import flattenPages from '@/utils/flattenPages';
 import { useParams } from 'next/navigation';
 import { RereplyItem } from './rereply-item';
 
@@ -42,7 +43,7 @@ export const RereplyList = ({
     hasNextPage,
   });
 
-  const rereplies = data.pages.flatMap((page) => page.items);
+  const rereplies = flattenPages(data.pages);
 
   return (
     <div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,3 +107,38 @@ export type Reply = {
   createdAt: string;
   isDeleted?: boolean; // 삭제된 댓글인지 여부
 };
+
+export type GroupDetail = {
+  groupInfo: {
+    groupId: number;
+    title: string;
+    description: string;
+    userId: number;
+    autoAllow: boolean;
+    currentParticipants: number;
+    maxParticipants: number;
+    status: boolean;
+    type: string;
+    views: number;
+    skills: string[];
+    positions: string[];
+    deadline: string;
+    startDate: string;
+    endDate: string;
+    userInfos: {
+      userId: number;
+      nickname: string;
+      profileImage: string;
+      email: string;
+    }[];
+  };
+  userInfo: {
+    userId: number;
+    nickname: string;
+    profileImage: string;
+    email: string;
+  };
+  applicant: boolean;
+  joined: boolean;
+  bookmark: boolean;
+};


### PR DESCRIPTION
## fix: 그룹 상세 페이지 API 변경 사항 적용 및 에러 처리

### 👩🏻‍💻 수정한 내용
- 모임 상세 페이지에서 받아오는 데이터 변경 사항 반영
- 모임 상세 페이지에서 데이터 요청이 실패하면 not-found 페이지로 이동하도록 변경
- 요청들에 credental:"include" 추가
- flattenPages 적용
- 댓글 리스트에 ErrorBoundary 적용