### PR TITLE
[FIX] 유저 페이지 관련 수정

### DIFF
--- a/src/components/error-boundary/error-handler.tsx
+++ b/src/components/error-boundary/error-handler.tsx
@@ -26,7 +26,7 @@ export const handleError = ({
     }
     
     // 인증 에러
-    if (error.message.includes('401') || error.message.toLowerCase().includes('unauthorized')) {
+    if (error.message.includes('401') || error.message.toLowerCase().includes('unauthorized') || error.message.includes('refresh 만료')) {
       return (
         <ErrorFallback error={error} resetErrorBoundary={resetErrorBoundary}>
           로그인이 필요합니다

--- a/src/components/error-fallback/index.tsx
+++ b/src/components/error-fallback/index.tsx
@@ -30,7 +30,8 @@ export const ErrorFallback = ({
   const handleClick = () => {
     if (
       error?.message.includes('401') ||
-      error?.message.toLowerCase().includes('unauthorized')
+      error?.message.toLowerCase().includes('unauthorized') ||
+      error?.message.toLowerCase().includes('refresh 만료')
     ) {
       clearUser();
       console.log('401 에러 발생');
@@ -54,7 +55,8 @@ export const ErrorFallback = ({
         className="mt-2 text-white text-sm cursor-pointer bg-green-600"
       >
         {error?.message.includes('401') ||
-        error?.message.toLowerCase().includes('unauthorized')
+        error?.message.toLowerCase().includes('unauthorized') ||
+        error?.message.toLowerCase().includes('refresh 만료')
           ? '로그인하기'
           : '다시 시도'}
       </Button>

--- a/src/features/user/components/current-user-profile.tsx
+++ b/src/features/user/components/current-user-profile.tsx
@@ -45,7 +45,7 @@ export const CurrentUserProfile = () => {
           </div>
           <div className="flex flex-col gap-y-1 min-w-0">
             <div className="flex gap-x-2 min-w-0">
-              <span className="text-sm font-medium shrink-0">Skills</span>
+              <span className="text-sm font-medium shrink-0">기술스택</span>
               {skills && skills.length === 0 ? (
                 <p className="text-gray-700 text-sm">
                   설정된 기술스택이 없어요.
@@ -64,7 +64,7 @@ export const CurrentUserProfile = () => {
               )}
             </div>
             <div className="flex gap-x-1.5">
-              <span className="text-sm font-medium">E-mail</span>
+              <span className="text-sm font-medium">이메일</span>
               <span className="text-sm font-normal text-gray-700 line-clamp-1">
                 {email}
               </span>

--- a/src/features/user/follow/components/followers-list.tsx
+++ b/src/features/user/follow/components/followers-list.tsx
@@ -36,6 +36,7 @@ export const FollowersList = () => {
         refetchOnMount: true,
         staleTime: 0,
         retry: 0,
+        gcTime: 0,
       },
     });
 

--- a/src/features/user/follow/components/following-list.tsx
+++ b/src/features/user/follow/components/following-list.tsx
@@ -33,6 +33,7 @@ export const FollowingList = () => {
         refetchOnMount: true,
         staleTime: 0,
         retry: 0,
+        gcTime: 0,
       },
     });
 

--- a/src/features/user/hooks/useChangePassword.ts
+++ b/src/features/user/hooks/useChangePassword.ts
@@ -33,9 +33,10 @@ export const useChangePassword = () => {
         description: '비밀번호가 변경되었어요',
       });
     },
-    onError() {
+    onError(error) {
+      const errInfo = JSON.parse(error.message.split('-')[1]);
       toast.error('비밀번호 변경 실패', {
-        description: '비밀번호 변경에 실패했어요. 잠시 후 다시 시도해주세요.',
+        description: errInfo.status.message,
       });
     },
   });

--- a/src/features/user/utils/validateImageFile.ts
+++ b/src/features/user/utils/validateImageFile.ts
@@ -13,7 +13,7 @@
  */
 export const validateImageFile = (
   file: File,
-  maxFileSize = 5 * 1024 * 1024,
+  maxFileSize = 1024 * 1024,
 ): { isValid: boolean; errorMessage?: string } => {
   if (!file.type.startsWith('image/')) {
     return {


### PR DESCRIPTION
## fix: 유저 페이지 관련 수정

### 👩🏻‍💻 작업한 내용

- 업로드할 프로필 이미지 파일 크기 1MB이하로 제한
- 일부 텍스트 변경
- 비밀번호 수정 실패 관련 메시지 수정
- 에러 메시지가 "refresh 토큰 만료" 인 경우에도 401 관련 fallback ui 보이도록 변경

### 💡 참고 사항

- 개발하긴 했는 데 좀 찝찝하거나 궁금했던것들
- 중점적으로 봐줬으면 하는 부분

### 🔗 참고 링크

- figma
- stackoverflow
- 미팅 노트(notion)

---